### PR TITLE
ci: update coverage job to depend on test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,4 +139,4 @@ workflows:
             - unit-test
       - coverage:
           requires:
-            - build
+            - test


### PR DESCRIPTION
Updates the coverage job to depend on the test job instead of just build, ensuring the coverage report generates only after all tests complete.